### PR TITLE
use full url always for noizd

### DIFF
--- a/src/types/platforms/noizd.ts
+++ b/src/types/platforms/noizd.ts
@@ -60,7 +60,7 @@ const mapAPITrack: (apiTrack: NOIZDAPITrack) => ProcessedTrack = (apiTrack: any)
     slug: slugify(`${apiTrack.title} ${mapAPITrackTime(apiTrack).getTime()}`).toLowerCase(),
     description: apiTrack.description,
     platformId: MusicPlatform.noizd,
-    lossyAudioURL: apiTrack.metadata ? apiTrack.metadata.audio_url : apiTrack.full.url,
+    lossyAudioURL: apiTrack.full.url,
     createdAtTime: mapAPITrackTime(apiTrack),
     lossyArtworkURL: artwork,
     websiteUrl: `https://noizd.com/assets/${apiTrack.id}`,


### PR DESCRIPTION
Note: This cannot be merged until the NOIZD backend includes the full object in NFT queries, or we add an extra api request to get the music object.